### PR TITLE
Adjusted the addon to the API change in Blender 2.63

### DIFF
--- a/blender_addons/io_mesh_terasology/__init__.py
+++ b/blender_addons/io_mesh_terasology/__init__.py
@@ -1,17 +1,11 @@
 #!BPY
-"""
-Name: 'TerasologyBlockShapeExport'
-Blender: 262
-Group: 'Export'
-Tooltip: 'Export a Terasology Block Shape'
-"""
 
 bl_info = {
 	"name": "Terasology Block Shape Export",
 	"description": "Exporter for producing Terasology Block Shape files (in JSON format)",
 	"author": "Immortius",
 	"version": (1, 3),
-	"blender": (2, 6, 0),
+	"blender": (2, 6, 3),
 	"location": "File > Import-Export",
 	"category": "Import-Export"}
 

--- a/blender_addons/io_mesh_terasology/export_block_shape.py
+++ b/blender_addons/io_mesh_terasology/export_block_shape.py
@@ -198,10 +198,13 @@ def writeMeshPart(name,
 	else:
 		mesh = obj.data
 		
+	
+	mesh.update(calc_tessface=True)
+
 	processedVerts = []
-	processedFaces = [[] for f in range(len(mesh.faces))]
+	processedFaces = [[] for f in range(len(mesh.tessfaces))]
 		
-	for i, f in enumerate(mesh.faces):
+	for i, f in enumerate(mesh.tessfaces):
 		faceVerts = f.vertices
 		for j, index in enumerate(faceVerts):
 			vert = mesh.vertices[index]
@@ -211,7 +214,7 @@ def writeMeshPart(name,
 				normal = tuple(f.normal)
 			else:
 				normal = tuple(vert.normal)
-			uvtemp = mesh.uv_textures.active.data[i].uv[j]
+			uvtemp = mesh.tessface_uv_textures.active.data[i].uv[j]
 			uvs = uvtemp[0], 1.0 - uvtemp[1]
 			
 			processedFaces[i].append(len(processedVerts))


### PR DESCRIPTION
The addon is broken since Blender 2.63.

With this change the addon should be compatible again with Blender 2.63 till the newest version 2.77a. I tested it only with Blender 2.77a.