### PR TITLE
Expand collapse buttons of tree view: SVG source file

### DIFF
--- a/art/expandCollapseButtons.svg
+++ b/art/expandCollapseButtons.svg
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   width="64"
+   height="32"
+   sodipodi:docname="expandCollapseButtons4.svg"
+   inkscape:export-filename="/home/flo/terasology/TeraMisc/art/expandCollapseButtons4.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <linearGradient
+       id="linearGradient4730">
+      <stop
+         style="stop-color:#c8c8c8;stop-opacity:1;"
+         offset="0"
+         id="stop4732" />
+      <stop
+         style="stop-color:#787878;stop-opacity:1;"
+         offset="1"
+         id="stop4734" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3948">
+      <stop
+         style="stop-color:#828282;stop-opacity:1;"
+         offset="0"
+         id="stop3950" />
+      <stop
+         style="stop-color:#3b3b3b;stop-opacity:1;"
+         offset="1"
+         id="stop3952" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3948"
+       id="radialGradient3954"
+       cx="98.675896"
+       cy="33.77449"
+       fx="98.675896"
+       fy="33.77449"
+       r="6.5172391"
+       gradientTransform="matrix(1.2553441,0,0,0.63763537,-108.89952,-7.1600886)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3948-9"
+       id="radialGradient3976-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5163674,-0.00705462,0.00296645,0.63762847,-102.74925,-6.6147015)"
+       cx="99.335144"
+       cy="34.495544"
+       fx="99.335144"
+       fy="34.495544"
+       r="6.5172391" />
+    <linearGradient
+       id="linearGradient3948-9">
+      <stop
+         style="stop-color:#828282;stop-opacity:1;"
+         offset="0"
+         id="stop3950-8" />
+      <stop
+         style="stop-color:#3b3b3b;stop-opacity:1;"
+         offset="1"
+         id="stop3952-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3948-0"
+       id="radialGradient3976-76"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5163674,-0.00705462,0.00296645,0.63762847,-102.74925,-6.6147015)"
+       cx="99.335144"
+       cy="34.495544"
+       fx="99.335144"
+       fy="34.495544"
+       r="6.5172391" />
+    <linearGradient
+       id="linearGradient3948-0">
+      <stop
+         style="stop-color:#828282;stop-opacity:1;"
+         offset="0"
+         id="stop3950-1" />
+      <stop
+         style="stop-color:#3b3b3b;stop-opacity:1;"
+         offset="1"
+         id="stop3952-0" />
+    </linearGradient>
+    <radialGradient
+       r="6.5172391"
+       fy="34.495544"
+       fx="99.335144"
+       cy="34.495544"
+       cx="99.335144"
+       gradientTransform="matrix(1.5163674,-0.00705462,0.00296645,0.63762847,-64.493848,6.5983913)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4076-5"
+       xlink:href="#linearGradient3948-0-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3948-0-1">
+      <stop
+         style="stop-color:#828282;stop-opacity:1;"
+         offset="0"
+         id="stop3950-1-9" />
+      <stop
+         style="stop-color:#3b3b3b;stop-opacity:1;"
+         offset="1"
+         id="stop3952-0-7" />
+    </linearGradient>
+    <filter
+       id="filter4012-2-7"
+       inkscape:label="Bloom"
+       x="0"
+       y="0"
+       width="1"
+       height="1"
+       inkscape:menu="Bevels"
+       inkscape:menu-tooltip="Soft, cushion-like bevel with matte highlights"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur4129-92-6"
+         result="result1"
+         in="SourceAlpha"
+         stdDeviation="1" />
+      <feSpecularLighting
+         id="feSpecularLighting4131-8-8"
+         result="result0"
+         specularExponent="8.11200047"
+         specularConstant="1.35869563"
+         surfaceScale="1">
+        <feDistantLight
+           id="feDistantLight4133-1-1"
+           azimuth="225"
+           elevation="24" />
+      </feSpecularLighting>
+      <feComposite
+         id="feComposite4135-2-3"
+         in2="SourceAlpha"
+         result="result6"
+         operator="in" />
+      <feMorphology
+         id="feMorphology4137-4-6"
+         radius="5.7"
+         operator="dilate" />
+      <feGaussianBlur
+         id="feGaussianBlur4139-78-4"
+         result="result11"
+         stdDeviation="5.7" />
+      <feDiffuseLighting
+         id="feDiffuseLighting4141-6-0"
+         surfaceScale="5"
+         result="result3"
+         diffuseConstant="2"
+         in="result1">
+        <feDistantLight
+           id="feDistantLight4143-3-3"
+           elevation="25"
+           azimuth="225" />
+      </feDiffuseLighting>
+      <feBlend
+         id="feBlend4145-7-5"
+         in2="SourceGraphic"
+         result="result7"
+         mode="multiply"
+         in="result3" />
+      <feComposite
+         id="feComposite4147-7-8"
+         in2="SourceAlpha"
+         in="result7"
+         operator="in"
+         result="result91" />
+      <feBlend
+         id="feBlend4149-2-5"
+         in2="result91"
+         result="result9"
+         mode="lighten"
+         in="result6" />
+      <feComposite
+         id="feComposite4151-3-0"
+         in2="result9"
+         in="result11"
+         result="result92" />
+      <feComposite
+         in="result92"
+         in2="SourceAlpha"
+         id="feComposite4153-7-9"
+         operator="in" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1429"
+     inkscape:window-height="963"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="5.4375"
+     inkscape:cx="27.083429"
+     inkscape:cy="-3.2238567"
+     inkscape:window-x="284"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <path
+     style="fill:#000000;fill-opacity:0;stroke:none"
+     d="m 103.49269,96.493755 6.48276,6.620685 6.55172,-6.597697 z"
+     id="path3068"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc"
+     inkscape:transform-center-x="17.685797"
+     inkscape:transform-center-y="-71.263359" />
+  <path
+     style="fill:url(#radialGradient3954);fill-opacity:1;stroke:none;filter:url(#filter4012-2-7)"
+     d="m 7.81862,11.844378 8.13809,8.311244 8.22467,-8.282386 z"
+     id="path3068-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc"
+     inkscape:transform-center-x="22.20176"
+     inkscape:transform-center-y="-89.460038" />
+  <path
+     style="fill:#646464;fill-opacity:1;stroke:none;filter:url(#filter4012-2-7)"
+     d="M 44.50816,24.181381 52.8194,16.043289 44.53702,7.8186192 z"
+     id="path4481-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc"
+     inkscape:transform-center-x="22.20176"
+     inkscape:transform-center-y="-89.460038" />
+</svg>

--- a/blender_addons/io_mesh_terasology/__init__.py
+++ b/blender_addons/io_mesh_terasology/__init__.py
@@ -1,17 +1,11 @@
 #!BPY
-"""
-Name: 'TerasologyBlockShapeExport'
-Blender: 262
-Group: 'Export'
-Tooltip: 'Export a Terasology Block Shape'
-"""
 
 bl_info = {
 	"name": "Terasology Block Shape Export",
 	"description": "Exporter for producing Terasology Block Shape files (in JSON format)",
 	"author": "Immortius",
 	"version": (1, 3),
-	"blender": (2, 6, 0),
+	"blender": (2, 6, 3),
 	"location": "File > Import-Export",
 	"category": "Import-Export"}
 

--- a/blender_addons/io_mesh_terasology/export_block_shape.py
+++ b/blender_addons/io_mesh_terasology/export_block_shape.py
@@ -198,10 +198,13 @@ def writeMeshPart(name,
 	else:
 		mesh = obj.data
 		
+	
+	mesh.update(calc_tessface=True)
+
 	processedVerts = []
-	processedFaces = [[] for f in range(len(mesh.faces))]
+	processedFaces = [[] for f in range(len(mesh.tessfaces))]
 		
-	for i, f in enumerate(mesh.faces):
+	for i, f in enumerate(mesh.tessfaces):
 		faceVerts = f.vertices
 		for j, index in enumerate(faceVerts):
 			vert = mesh.vertices[index]
@@ -211,7 +214,7 @@ def writeMeshPart(name,
 				normal = tuple(f.normal)
 			else:
 				normal = tuple(vert.normal)
-			uvtemp = mesh.uv_textures.active.data[i].uv[j]
+			uvtemp = mesh.tessface_uv_textures.active.data[i].uv[j]
 			uvs = uvtemp[0], 1.0 - uvtemp[1]
 			
 			processedFaces[i].append(len(processedVerts))


### PR DESCRIPTION
A SVG i created in order to make the tree view expand/collapse arrows.

The SVG contains only the bright version of them. The darker versions were made by just darkening the exported png.

See MovingBlocks/Terasology#2373 for the addition of the final images to terasology.