### PR TITLE
Added the json files as string

### DIFF
--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1106,7 +1106,8 @@ def exportPrefabForTerasology(assetDirectory, report = print):
   data["WildAnimal"]["name"] = modelName[:1].upper()+modelName[1:]
   data["WildAnimal"]["icon"] = "WildAnimals:"+modelName+"Icon"
 
-  for action in bpy.context.screen.action_group:
+  for action in bpy.data.scenes:
+    print (action.name)
     if "stand" in action.name.lower() or "idle" in action.name.lower():
       data["Stand"]["animationPool"].append(modelName+action.name)
     elif "walk" in action.name.lower():
@@ -1148,9 +1149,9 @@ def exportMaterialForTerasology(assetDirectory, report = print):
 def exportModuleForTerasology(parentDirectory, fileName, report = print):
   data = json.loads(moduleData, object_pairs_hook = OrderedDict)
   modelName  = getSuggestedModelName()
-  data["id"] = fileName
+  data["id"] = (os.path.splitext(fileName)[0])[:1].upper() + (os.path.splitext(fileName)[0])[1:].lower()
   data["displayName"] = modelName
-  data["description"] = "This module contains a single " + modelName + " model that can be spawned with spawnPrefab" + modelName + ". The module has been generated with the Blender addon from the TeraMisc repository"
+  data["description"] = "This module contains a single " + modelName + " model that can be spawned with spawnPrefab " + modelName + ". The module has been generated with the Blender addon from the TeraMisc repository"
   # data["author"] = getpass.getuser()
   data["version"] = "0.1.1-SNAPSHOT"
 
@@ -1269,10 +1270,8 @@ class ExportZipFileForTerasology(bpy.types.Operator):
   bl_label =  "Export Zip"
 
   filepath = StringProperty(subtype = 'FILE_PATH',name="File Path", description="Filepath for exporting", maxlen= 1024, default= "")
-  zipname = StringProperty(name="zip Name", description="Name for the zip to be exported",maxlen=64,default="")
 
   def execute(self, context):
-    print(self.properties.filepath)
     global scale
     scale = 1.0
     zipExportPath = self.properties.filepath + ".jar"
@@ -1396,8 +1395,9 @@ class TerasologyExportPanel(bpy.types.Panel):
 
 def menu_func(self, context):
   default_path = os.path.splitext(bpy.data.filepath)[0]
+  zip_path = os.path.join(os.path.dirname(default_path), ((os.path.basename(default_path))[:1].upper()+(os.path.basename(default_path))[1:].lower()) + "-0.1.1-SNAPSHOT")
   self.layout.operator(ExportMD5.bl_idname, text="idTech 4 MD5 (.md5mesh .md5anim)", icon='BLENDER').filepath = default_path
-  self.layout.operator(ExportZipFileForTerasology.bl_idname, text="Export zip for Terasology", icon='BLENDER').filepath = default_path
+  self.layout.operator(ExportZipFileForTerasology.bl_idname, text="Export zip for Terasology", icon='BLENDER').filepath = zip_path
   # self.layout.operator(ExportModuleToFileForTerasology.bl_idname, text="Export module to directory", icon='BLENDER').filepath = default_path
     
 class CustomProp(bpy.types.PropertyGroup):

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1263,7 +1263,7 @@ import zipfile,os
 class ExportZipFileForTerasology(bpy.types.Operator):
   '''Create a ready to use module(.jar) that can be directly used in Terasology'''
   bl_idname = "export.zipfile"
-  bl_label =  "Export module"
+  bl_label =  "Export Zip"
 
   filepath = StringProperty(subtype = 'FILE_PATH',name="File Path", description="Filepath for exporting", maxlen= 1024, default= "")
   zipname = StringProperty(name="zip Name", description="Name for the zip to be exported",maxlen=64,default="")
@@ -1296,8 +1296,8 @@ class ExportZipFileForTerasology(bpy.types.Operator):
       i = 0;
       for f in files:
         fn = os.path.join(dirpath, f)
-        zipf.write(fn, "/assets/animations/" + context.scene.action_group[i].name+".md5anim")
-        context.scene.action_group[i].name
+        zipf.write(fn, "/assets/animations/" + modelName + bpy.data.scenes[i].name+".md5anim")
+        bpy.data.scenes[i].name
         i = i+1
     # shutil.rmtree(dirpath)
 

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1224,12 +1224,15 @@ class ExportModuleToFileForTerasology(bpy.types.Operator):
   bl_label = "Export module"
 
   filepath = StringProperty(subtype = 'FILE_PATH',name="File Path", description="Filepath for exporting", maxlen= 1024, default= "")
+  filename = StringProperty(subtype = 'FILE_NAME',name="Folder Name", description="Folder Name for exporting", maxlen= 1024, default= "bhbhb")
 
   def execute(self, context):
     global scale
     scale = 1.0
     global scale
     scale = 1.0
+    if self.properties.filename != "":
+      os.makedirs(self.properties.filepath)
     dirpath = self.properties.filepath
     assetDirectory = os.path.join(dirpath, "assets")
     fileName = os.path.basename(os.path.normpath(dirpath))

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -53,6 +53,88 @@ moduleData = """{
 }"""
 
 
+prefabData = """{
+  "skeletalmesh" : {
+    "mesh" : "",
+    "heightOffset" : -0.8,
+    "material" : "",
+    "animation" : "",
+    "loop" : true
+  },
+  "Behavior" : {
+    "tree" : "stray"
+  },
+  "FleeOnHit" : {
+    "minDistance" : 5,
+    "speedMultiplier" : 1.2
+  },
+  "StrayIfIdle" : {
+    "defaultSpeedMultiplier" : 0.3
+  },
+  "BlockDropGrammar": {
+    "blockDrops": [],
+    "itemDrops": ["2*WildAnimals:meat"]
+  },
+  "Stand" :{
+    "animationPool": []
+  },
+  "Walk" :{
+    "animationPool": []
+  },
+  "Die" :{
+    "animationPool": []
+  },
+  "persisted" : true,
+  "location" : {},
+  "Character" : {},
+  "AliveCharacter": {},
+  "WildAnimal" : {
+    "name": "",
+    "icon": ""
+  },
+  "NPCMovement" : {},
+  "CreatureNameGenerator" : {
+    "genderRatio" : 0.5,
+    "nobility" : 0.5,
+    "theme": "DWARF"
+  },
+  "CharacterMovement" : {
+    "groundFriction" : 16,
+    "speedMultiplier" : 0.3,
+    "distanceBetweenFootsteps" : 0.2,
+    "distanceBetweenSwimStrokes" : 2.5,
+    "height" : 1.6,
+    "radius" : 0.3,
+    "jumpSpeed" : 12
+  },
+  "CharacterSound" : {
+    "footstepSounds" : ["FootGrass1", "FootGrass2", "FootGrass3", "FootGrass4", "FootGrass5"],
+    "footstepVolume" : 0.03
+  },
+  "Network" :{},
+  "MinionMove" : {},
+  "Health" : {
+    "destroyEntityOnNoHealth" : true,
+    "currentHealth": 7
+  },
+  "BoxShape" : {
+    "extents" : [1.5, 1.5, 1.5]
+  },
+  "Trigger" : {
+    "detectGroups" : ["engine:debris", "engine:sensor"]
+  }
+}"""
+
+materialData = """{
+    "shader" : "engine:genericMeshMaterial",
+    "params" : {
+        "diffuse" : "deer",
+        "colorOffset" : [1.0, 1.0, 1.0],
+        "textured" : true
+    }
+}
+"""
+
 #MATH UTILTY
 
 def vector_crossproduct(v1, v2):
@@ -1014,9 +1096,7 @@ import os,json
 from collections import OrderedDict
 def exportPrefabForTerasology(assetDirectory, report = print):
   current_file_dir = os.path.dirname(__file__)
-  file_in_path=os.path.join(current_file_dir, "template.prefab")
-  with open(file_in_path, 'r') as inFile:
-    data = json.load(inFile, object_pairs_hook=OrderedDict)
+  data = json.loads(prefabData, object_pairs_hook=OrderedDict)
 
   modelName = getSuggestedModelName().lower()
 
@@ -1048,9 +1128,7 @@ def exportPrefabForTerasology(assetDirectory, report = print):
 
 def exportMaterialForTerasology(assetDirectory, report = print):
   current_file_dir = os.path.dirname(__file__)
-  file_in_path=os.path.join(current_file_dir,"templateSkin.mat")
-  with open(file_in_path, 'r') as inFile:
-    data = json.load(inFile, object_pairs_hook = OrderedDict)
+  data = json.loads(materialData, object_pairs_hook = OrderedDict)
 
   modelName = getSuggestedModelName()
 
@@ -1141,7 +1219,7 @@ class ExportTextureForTerasology(bpy.types.Operator):
     return{'FINISHED'}
 
 class ExportModuleToFileForTerasology(bpy.types.Operator):
-  '''Export the module into a directory'''
+  '''Export the module into the directory specified'''
   bl_idname = "export.module"
   bl_label = "Export module"
 

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1369,7 +1369,7 @@ class TerasologyExportPanel(bpy.types.Panel):
         col.operator("export.prefab", text="Export prefab file")
         col.operator("export.texture", text="Export texture file")
         col.operator("export.material", text="Export material file")
-        # col.operator("create.zipfile")
+        col.operator("create.zipfile")
         # col.operator(TerasologyMD5MeshAndAnimExportOperator.bl_idname, text="Export Both")
         layout.label(text="Note: Blend & scene name determines model file name")
 

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1007,7 +1007,7 @@ def exportPrefabForTerasology():
   with open(file_in_path, 'r') as inFile:
     data = json.load(inFile, object_pairs_hook=OrderedDict)
 
-  modelName=getSuggestedModelName()
+  modelName = getSuggestedModelName()
 
   data["skeletalmesh"]["mesh"] = modelName
   data["skeletalmesh"]["material"] = modelName+"Skin"
@@ -1015,16 +1015,36 @@ def exportPrefabForTerasology():
   data["WildAnimal"]["name"] = modelName[:1].upper()+modelName[1:]
   data["WildAnimal"]["icon"] = "WildAnimals:"+modelName+"Icon"
   # data["Die"]["animationPool"]="["+findAnimation("death")+"]"
+
   assetDirectory = getTargetTerasologyAssetsDirectory(bpy.context)
-  prefabDirectory = os.path.join(assetDirectory,"prefab")
+  prefabDirectory = os.path.join(assetDirectory,"prefabs")
   fileName = modelName+".prefab"
   createDirectoryForFileIfMissing(os.path.join(prefabDirectory,fileName))
-  print("Exporting prefab at: "+prefabDirectory)
+  print("Exporting prefab at: " + prefabDirectory)
   with open(os.path.join(prefabDirectory,fileName),"w") as outFile:
     json.dump(data, outFile, indent=2)
 
   return None
 
+def exportMaterialForTerasology():
+  current_file_dir = os.path.dirname(__file__)
+  file_in_path=os.path.join(current_file_dir,"templateSkin.mat")
+  with open(file_in_path, 'r') as inFile:
+    data = json.load(inFile, object_pairs_hook=OrderedDict)
+
+  modelName = getSuggestedModelName()
+
+  data["params"]["diffuse"] = modelName
+
+  assetDirectory = getTargetTerasologyAssetsDirectory(bpy.context)
+  materialDirectory = os.path.join(assetDirectory,"materials")
+  fileName = modelName+"Skin.mat"
+  createDirectoryForFileIfMissing(os.path.join(materialDirectory,fileName))
+  print("Exporting material file at: " + materialDirectory)
+  with open(os.path.join(materialDirectory,fileName),"w") as outFile:
+    json.dump(data, outFile, indent=2)
+
+  return None
 
 class ExportPrefabForTerasology(bpy.types.Operator):
   bl_idname = "export.prefab"
@@ -1035,8 +1055,16 @@ class ExportPrefabForTerasology(bpy.types.Operator):
 
     return{'FINISHED'}
 
+class ExportMaterialForTerasology(bpy.types.Operator):
+  bl_idname = "export.material"
+  bl_label = "Export a material for Terasology"
 
-import zipfile,os
+  def invoke(self, context, event):
+    exportMaterialForTerasology()
+
+    return{'FINISHED'}
+
+import zipfile,os,tempfile
 class ExportZipFileForTerasology(bpy.types.Operator):
   bl_idname = "create.zipfile"
   bl_label =  "Create a ZipFile for exporting the content"
@@ -1155,7 +1183,8 @@ class TerasologyExportPanel(bpy.types.Panel):
         col.operator("scene.populate")
         col.template_list("actionlist_UL", "", scene, "action_group", scene, "action_list_index")
         col.operator(TerasologyMD5AnimExportOperator.bl_idname, text="Export Selected Animations" )
-        col.operator("export.prefab",text="Export prefab file")
+        col.operator("export.prefab", text="Export prefab file")
+        col.operator("export.material", text="Export material file")
         col.operator("create.zipfile",text ="Export ZipFile")
         # col.operator(TerasologyMD5MeshAndAnimExportOperator.bl_idname, text="Export Both")
         layout.label(text="Note: Blend & scene name determines model file name")

--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -771,6 +771,9 @@ def createDirectoryForFileIfMissing(filePath):
   if not os.path.exists(directory):
     os.makedirs(directory)
 
+def capitalizeFirstLetter(string):
+  return string[:1].upper() + string[1:].lower()
+
 #SERIALIZE FUNCTION
 def save_md5(modelFilePath=None, animationFilePath=None):
   """
@@ -1103,7 +1106,7 @@ def exportPrefabForTerasology(assetDirectory, report = print):
   data["skeletalmesh"]["mesh"] = modelName
   data["skeletalmesh"]["material"] = modelName+"Skin"
   data["skeletalmesh"]["animation"] = modelName+"Idle"#later check if the animation actually exists
-  data["WildAnimal"]["name"] = modelName[:1].upper()+modelName[1:]
+  data["WildAnimal"]["name"] = capitalizeFirstLetter(modelName)
   data["WildAnimal"]["icon"] = "WildAnimals:"+modelName+"Icon"
 
   for action in bpy.data.scenes:
@@ -1133,7 +1136,7 @@ def exportMaterialForTerasology(assetDirectory, report = print):
 
   modelName = getSuggestedModelName()
 
-  data["params"]["diffuse"] = modelName
+  data["params"]["diffuse"] = modelName + "Texture"
 
   # assetDirectory = getTargetTerasologyAssetsDirectory(bpy.context)
   materialDirectory = os.path.join(assetDirectory,"materials")
@@ -1149,8 +1152,8 @@ def exportMaterialForTerasology(assetDirectory, report = print):
 def exportModuleForTerasology(parentDirectory, fileName, report = print):
   data = json.loads(moduleData, object_pairs_hook = OrderedDict)
   modelName  = getSuggestedModelName()
-  data["id"] = (os.path.splitext(fileName)[0])[:1].upper() + (os.path.splitext(fileName)[0])[1:].lower()
-  data["displayName"] = modelName
+  data["id"] = capitalizeFirstLetter(modelName)
+  data["displayName"] = capitalizeFirstLetter(modelName)
   data["description"] = "This module contains a single " + modelName + " model that can be spawned with spawnPrefab " + modelName + ". The module has been generated with the Blender addon from the TeraMisc repository"
   # data["author"] = getpass.getuser()
   data["version"] = "0.1.1-SNAPSHOT"
@@ -1167,7 +1170,7 @@ from shutil import copy
 def exportTextureForTerasology(assetDirectory, report = print):
   blendFilePath = bpy.path.abspath("//")
   modelName = getSuggestedModelName()
-  textureFileName = modelName[:1].upper()+modelName[1:] + "Texture.png"
+  textureFileName = capitalizeFirstLetter(modelName) + "Texture.png"
   texturePathAlternate = os.path.join(blendFilePath,textureFileName)
   texturePath = bpy.path.abspath(bpy.data.images[0].filepath)
   textureDirectory = os.path.join(assetDirectory,"textures")
@@ -1241,7 +1244,7 @@ class ExportModuleToFileForTerasology(bpy.types.Operator):
     modelFileName = modelName + ".md5mesh"
     animationFileName = modelName + ".md5anim"
     prefabFileName = modelName.lower() + ".prefab"
-    textureFileName = modelName[:1].upper()+modelName[1:] + "Texture.png"
+    textureFileName = capitalizeFirstLetter(modelName) + "Texture.png"
     materialFileName = modelName.lower() + "Skin.mat"
     exportModuleForTerasology(dirpath, fileName, self.report)
     exportTextureForTerasology(assetDirectory, self.report)
@@ -1281,7 +1284,7 @@ class ExportZipFileForTerasology(bpy.types.Operator):
     modelFileName = modelName + ".md5mesh"
     animationFileName = modelName + ".md5anim"
     prefabFileName = modelName.lower() + ".prefab"
-    textureFileName = modelName[:1].upper()+modelName[1:] + "Texture.png"
+    textureFileName = capitalizeFirstLetter(modelName) + "Texture.png"
     materialFileName = modelName.lower() + "Skin.mat"
     dirpath = tempfile.mkdtemp()
     exportModuleForTerasology(dirpath, fileName, self.report)
@@ -1395,7 +1398,7 @@ class TerasologyExportPanel(bpy.types.Panel):
 
 def menu_func(self, context):
   default_path = os.path.splitext(bpy.data.filepath)[0]
-  zip_path = os.path.join(os.path.dirname(default_path), ((os.path.basename(default_path))[:1].upper()+(os.path.basename(default_path))[1:].lower()) + "-0.1.1-SNAPSHOT")
+  zip_path = os.path.join(os.path.dirname(default_path), capitalizeFirstLetter(os.path.basename(default_path)) + "-0.1.1-SNAPSHOT")
   self.layout.operator(ExportMD5.bl_idname, text="idTech 4 MD5 (.md5mesh .md5anim)", icon='BLENDER').filepath = default_path
   self.layout.operator(ExportZipFileForTerasology.bl_idname, text="Export zip for Terasology", icon='BLENDER').filepath = zip_path
   # self.layout.operator(ExportModuleToFileForTerasology.bl_idname, text="Export module to directory", icon='BLENDER').filepath = default_path

--- a/blender_addons/io_md5_exporter/templateSkin.mat
+++ b/blender_addons/io_md5_exporter/templateSkin.mat
@@ -1,0 +1,9 @@
+
+{
+    "shader" : "engine:genericMeshMaterial",
+    "params" : {
+        "diffuse" : "deer",
+        "colorOffset" : [1.0, 1.0, 1.0],
+        "textured" : true
+    }
+}


### PR DESCRIPTION
The script exports models and animations from blender. 
1. To export a ready to use module navigate to File->Export->Expor zip for Terasology. 
2. Individual files can also be exported using a panel to select the folder in which to export the files. 
3. Clicking the "+" next to the path exports the entire module in the folder and changes the path for future exports to the new folder. 
4. Exporting multiple actions is now supported using the scene switch method rather than the action method. 
5. The prefab which is exported contains the list of animations roughly according to the naming conventions.
6. The code now contains the template prefab and template material json so there is no need to copy it to the addon directory.
7. Texture files export works by checking if the model is linked with a texture otherwise it checks for a texture named <modelName>Texture.png in the folder of the .blend file (here <modelName> starts with a capital letter).