### PR TITLE
Multiple texture support containing the modelname

### DIFF
--- a/blender_addons/io_md5_exporter/io_export_md5.py
+++ b/blender_addons/io_md5_exporter/io_export_md5.py
@@ -1139,7 +1139,12 @@ def exportMaterialForTerasology(assetDirectory, report = print):
 
   modelName = getSuggestedModelName()
 
-  data["params"]["diffuse"] = modelName + "Texture"
+  blendFilePath = bpy.path.abspath("//")
+  for fileName in os.listdir(blendFilePath):
+    if modelName.lower() in str(fileName.lower()) and ".png" in str(fileName.lower()):
+      break
+
+  data["params"]["diffuse"] = os.path.splitext(fileName)[0]
 
   # assetDirectory = getTargetTerasologyAssetsDirectory(bpy.context)
   materialDirectory = os.path.join(assetDirectory,"materials")
@@ -1185,6 +1190,9 @@ def exportTextureForTerasology(assetDirectory, report = print):
   if not os.path.exists(textureDirectory):
     os.makedirs(textureDirectory)
 
+  for fileName in os.listdir(blendFilePath):
+    if modelName.lower() in str(fileName.lower()) and ".png" in str(fileName.lower()):
+      copy(os.path.join(blendFilePath, fileName), textureDirectory)
   if os.path.isfile(texturePath):
     copy(texturePath, textureDirectory)
     
@@ -1198,8 +1206,8 @@ def exportTextureForTerasology(assetDirectory, report = print):
     copy(texturePathAlternate2, textureDirectory)
     report({'INFO'}, "Texture Exported")
   else:
-    report({'ERROR'}, "Texture File must be present in same folder as the .blend file named " + textureFileName)
-    return{'ERROR'}
+        report({'ERROR'}, "Texture File must be present in same folder as the .blend file named " + textureFileName)
+        return{'ERROR'}
 
   # assetDirectory = getTargetTerasologyAssetsDirectory(bpy.context)
   
@@ -1308,7 +1316,8 @@ class ExportZipFileForTerasology(bpy.types.Operator):
     exportModuleForTerasology(dirpath, fileName)
     zipf.write(os.path.join(dirpath,"module.txt"), "module.txt")
     exportTextureForTerasology(dirpath)
-    zipf.write(os.path.join(dirpath,"textures",textureFileName), "assets/textures/"+textureFileName)
+    for fileTexture in os.listdir(os.path.join(dirpath,"textures")):
+      zipf.write(os.path.join(dirpath, "textures", fileTexture), "assets/textures/"+fileTexture)
     exportPrefabForTerasology(dirpath)
     zipf.write(os.path.join(dirpath, "prefabs", prefabFileName), "assets/prefabs/"+prefabFileName)
     exportMaterialForTerasology(dirpath,)
@@ -1322,7 +1331,7 @@ class ExportZipFileForTerasology(bpy.types.Operator):
         zipf.write(fn, "/assets/animations/" + modelName + bpy.data.scenes[i].name+".md5anim")
         bpy.data.scenes[i].name
         i = i+1
-    # shutil.rmtree(dirpath)
+    shutil.rmtree(dirpath)
 
     zipf.close()
     self.report({'INFO'}, "Module Exported")


### PR DESCRIPTION
The code is in pretty bad condition with the new addition. I will add new functions for the tasks I am commonly using as flo suggested. The code right now searches for the files with modelName and .png in their name in the location where the .blend is placed. It also searches for file which are linked to the model. Also I figured that copying files with specific names out of temporary folders is not a good method so I will replace that with copying all files out of that folder (as implemented in this case) which will help us to expand further.
The first file found id added to the material file.
The zip sometimes does not open the first time and I am unable to figure out why as the message that the zip has closed is successfully printed.